### PR TITLE
Added low_memory error (to indicate no. of headers supplied is not sufficient)

### DIFF
--- a/picohttpparser.h
+++ b/picohttpparser.h
@@ -16,7 +16,9 @@ struct phr_header {
   size_t value_len;
 };
 
-/* returns number of bytes cosumed if successful, -2 if request is partial,
+/* returns number of bytes cosumed if successful, 
+ * -3 if the number of headers supplied is not enough,
+ * -2 if request is partial,
  * -1 if failed */
 int phr_parse_request(const char* buf, size_t len, const char** method,
 		      size_t* method_len, const char** path,


### PR DESCRIPTION
Please consider merging this modification: It tries to provide more useful information to the caller about the case where the parser fails due to the supplied header array not being sufficient. 

This will greatly help adjusting the header-array size (if required) or identify any denial-of-service / overflow kind of attacks.

The code uses #defines (only inside the .c file) to easily identify the semantics of errors. Please feel free to change the macro names, if required. Also, the header file comment is updated to include this new error number.

I left the #defines inside the .c file. But if it is ok with you, I really would like to see them inside .h file (so that the callers can use the macro names to compare the error codes, instead of hard-coded -2, -3 etc..). Easy to use in switch case statement. Let me know if the #defines are ok to move into the header file.

Error number -3 is used for tracking this memory error. So, this should not break compatibility with existing codes built on top of this.

Thank you for the great work and providing this library.
- GK (Gopalakrishna)
  
  http://gk.palem.in/ 
