### PR TITLE
stricter validation of header names

### DIFF
--- a/picohttpparser.c
+++ b/picohttpparser.c
@@ -305,7 +305,10 @@ static const char *parse_headers(const char *buf, const char *buf_end, struct ph
                 ++buf;
                 CHECK_EOF();
             }
-            headers[*num_headers].name_len = buf - headers[*num_headers].name;
+            if ((headers[*num_headers].name_len = buf - headers[*num_headers].name) == 0) {
+                *ret = -1;
+                return NULL;
+            }
             ++buf;
             for (;; ++buf) {
                 CHECK_EOF();

--- a/picohttpparser.c
+++ b/picohttpparser.c
@@ -93,7 +93,7 @@
     } while (0)
 
 static const char *token_char_map = "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
-                                    "\0\1\1\1\1\1\1\1\0\0\1\1\0\1\1\0\1\1\1\1\1\1\1\1\1\1\0\0\0\0\0\0"
+                                    "\0\1\0\1\1\1\1\1\0\0\1\1\0\1\1\0\1\1\1\1\1\1\1\1\1\1\0\0\0\0\0\0"
                                     "\0\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\0\0\0\1\1"
                                     "\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\0\1\0\1\0"
                                     "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
@@ -279,15 +279,18 @@ static const char *parse_headers(const char *buf, const char *buf_end, struct ph
             return NULL;
         }
         if (!(*num_headers != 0 && (*buf == ' ' || *buf == '\t'))) {
-            static const char ALIGNED(16) ranges1[] = "::\x00\037";
-            int found;
-            if (!token_char_map[(unsigned char)*buf]) {
-                *ret = -1;
-                return NULL;
-            }
             /* parsing name, but do not discard SP before colon, see
              * http://www.mozilla.org/security/announce/2006/mfsa2006-33.html */
             headers[*num_headers].name = buf;
+            static const char ranges1[] __attribute__((aligned(16))) = "\x00 "  /* control chars and up to SP */
+                                                                       "\"\""   /* 0x22 */
+                                                                       "()"     /* 0x28,0x29 */
+                                                                       ",,"     /* 0x2c */
+                                                                       "//"     /* 0x2f */
+                                                                       ":@"     /* 0x3a-0x40 */
+                                                                       "[]"     /* 0x5b-0x5d */
+                                                                       "{\377"; /* 0x7b-0xff */
+            int found;
             buf = findchar_fast(buf, buf_end, ranges1, sizeof(ranges1) - 1, &found);
             if (!found) {
                 CHECK_EOF();
@@ -295,7 +298,7 @@ static const char *parse_headers(const char *buf, const char *buf_end, struct ph
             while (1) {
                 if (*buf == ':') {
                     break;
-                } else if (*buf < ' ') {
+                } else if (!token_char_map[(unsigned char)*buf]) {
                     *ret = -1;
                     return NULL;
                 }

--- a/test.c
+++ b/test.c
@@ -124,6 +124,7 @@ static void test_request(void)
     PARSE("GET / HTTP/1.0\r\nab: c\0d\r\n\r\n", 0, -1, "NUL in header value");
     PARSE("GET / HTTP/1.0\r\na\033b: c\r\n\r\n", 0, -1, "CTL in header name");
     PARSE("GET / HTTP/1.0\r\nab: c\033\r\n\r\n", 0, -1, "CTL in header value");
+    PARSE("GET / HTTP/1.0\r\n/: 1\r\n\r\n", 0, -1, "invalid char in header value");
     PARSE("GET /\xa0 HTTP/1.0\r\nh: c\xa2y\r\n\r\n", 0, 0, "accept MSB chars");
     ok(num_headers == 1);
     ok(bufis(method, method_len, "GET"));

--- a/test.c
+++ b/test.c
@@ -94,13 +94,7 @@ static void test_request(void)
     ok(headers[2].name == NULL);
     ok(bufis(headers[2].value, headers[2].value_len, "  \tc"));
 
-    PARSE("GET / HTTP/1.0\r\nfoo : ab\r\n\r\n", 0, 0, "parse header name with trailing space");
-    ok(num_headers == 1);
-    ok(bufis(method, method_len, "GET"));
-    ok(bufis(path, path_len, "/"));
-    ok(minor_version == 0);
-    ok(bufis(headers[0].name, headers[0].name_len, "foo "));
-    ok(bufis(headers[0].value, headers[0].value_len, "ab"));
+    PARSE("GET / HTTP/1.0\r\nfoo : ab\r\n\r\n", 0, -1, "parse header name with trailing space");
 
     PARSE("GET", 0, -2, "incomplete 1");
     ok(method == NULL);


### PR DESCRIPTION
This PR implements a stricter validation of header names, using the same rules introduced to H2O in https://github.com/h2o/h2o/pull/974. The rule also matches that of Firefox (search `nsHttp::IsValidToken` in dxr.mozilla.org).

At the moment, the approach of the PR is to _reject_ handling of a HTTP request with an invalid header name. However, some _might_ want to try to use the request just by ignoring such headers. Note that this function would also be used for decoding an HTTP response sent from upstream servers in case of H2O used as a reverse proxy.

For that respect, the source code of Firefox states "we skip over mal-formed headers in the hope that we'll still be able to do something useful with the response" (see `nsHttpHeaderArray::ParseHeaderLine`), however the code looks like that it is actually rejecting such request (see `nsHttpTransaction::ParseHead` that just bails out when `ParseLineSegment` (a wrapper function of `ParseHeaderLine` returns an error).

Personally, I think rejecting a HTTP request is the way to go, considering the fact that the invalid header might have been processed by an intermediary before being received by an endpoint using picohttpparser, and since the risk of a disagreement between the intermediary and the endpoint cannot be resolved just by _dropping_ the header.

see also: http://www-archive.mozilla.org/security/announce/2006/mfsa2006-33.html