### PR TITLE
Fix memory leaks in tests

### DIFF
--- a/test.c
+++ b/test.c
@@ -314,7 +314,7 @@ static void test_chunked_per_byte(int line, int consume_trailer, const char *enc
         ret = phr_decode_chunked(&dec, buf + bytes_ready, &bufsz);
         if (ret != -2) {
             ok(0);
-            return;
+            goto cleanup;
         }
         bytes_ready += bufsz;
     }
@@ -332,6 +332,7 @@ static void test_chunked_per_byte(int line, int consume_trailer, const char *enc
             ok(0);
     }
 
+cleanup:
     free(buf);
 }
 
@@ -355,16 +356,17 @@ static void test_chunked_failure(int line, const char *encoded, ssize_t expected
         ret = phr_decode_chunked(&dec, buf, &bufsz);
         if (ret == -1) {
             ok(ret == expected);
-            return;
+            goto cleanup;
         } else if (ret == -2) {
             /* continue */
         } else {
             ok(0);
-            return;
+            goto cleanup;
         }
     }
     ok(ret == expected);
 
+cleanup:
     free(buf);
 }
 


### PR DESCRIPTION
Running the tests with `-fsanitize=address` makes ASan unhappy:

```
    ok 55 - test.c 223
    ok 56 - test.c 224
    # slowloris (incomplete)
    ok 57 - test.c 226

=================================================================
==22867==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 38 byte(s) in 1 object(s) allocated from:
    #0 0x7f8bc3e6e170 in __interceptor_strdup /build/gcc-multilib/src/gcc/libsanitizer/asan/asan_interceptors.cc:560
    #1 0x40902d in test_chunked_failure(int, char const*, long) (/home/inf/build/fuzz_pico/picohttpparser/test-bin+0x40902d)
    #2 0x409524 in test_chunked() (/home/inf/build/fuzz_pico/picohttpparser/test-bin+0x409524)
    #3 0x404fc2 in subtest(char const*, void (*)()) (/home/inf/build/fuzz_pico/picohttpparser/test-bin+0x404fc2)
    #4 0x409799 in main (/home/inf/build/fuzz_pico/picohttpparser/test-bin+0x409799)
    #5 0x7f8bc31f3290 in __libc_start_main (/usr/lib/libc.so.6+0x20290)

Direct leak of 11 byte(s) in 1 object(s) allocated from:
    #0 0x7f8bc3e6e170 in __interceptor_strdup /build/gcc-multilib/src/gcc/libsanitizer/asan/asan_interceptors.cc:560
    #1 0x40902d in test_chunked_failure(int, char const*, long) (/home/inf/build/fuzz_pico/picohttpparser/test-bin+0x40902d)
    #2 0x4094f8 in test_chunked() (/home/inf/build/fuzz_pico/picohttpparser/test-bin+0x4094f8)
    #3 0x404fc2 in subtest(char const*, void (*)()) (/home/inf/build/fuzz_pico/picohttpparser/test-bin+0x404fc2)
    #4 0x409799 in main (/home/inf/build/fuzz_pico/picohttpparser/test-bin+0x409799)
    #5 0x7f8bc31f3290 in __libc_start_main (/usr/lib/libc.so.6+0x20290)

SUMMARY: AddressSanitizer: 49 byte(s) leaked in 2 allocation(s).
    # s
Dubious, test returned 1 (wstat 256, 0x100)
All 1 subtests passed 

Test Summary Report
-------------------
./test-bin (Wstat: 256 Tests: 1 Failed: 0)
  Non-zero exit status: 1
  Parse errors: No plan found in TAP output
```

The commit fixes the leaks. I used gotos here. If you don't like them then I can change it to something else. I think it's fine here though.