### PR TITLE
check empty method and path

### DIFF
--- a/picohttpparser.c
+++ b/picohttpparser.c
@@ -362,6 +362,10 @@ static const char *parse_request(const char *buf, const char *buf_end, const cha
     ++buf;
     ADVANCE_TOKEN(*path, *path_len);
     ++buf;
+    if (*method_len == 0 || *path_len == 0) {
+        *ret = -1;
+        return NULL;
+    }
     if ((buf = parse_http_version(buf, buf_end, minor_version, ret)) == NULL) {
         return NULL;
     }

--- a/test.c
+++ b/test.c
@@ -114,6 +114,9 @@ static void test_request(void)
     PARSE("GET /hoge HTTP/1.0\r\n\r", strlen("GET /hoge HTTP/1.0\r\n\r") - 1, -2, "slowloris (incomplete)");
     PARSE("GET /hoge HTTP/1.0\r\n\r\n", strlen("GET /hoge HTTP/1.0\r\n\r\n") - 1, 0, "slowloris (complete)");
 
+    PARSE(" / HTTP/1.0\r\n\r\n", 0, -1, "empty method");
+    PARSE("GET  HTTP/1.0\r\n\r\n", 0, -1, "empty request-target");
+
     PARSE("GET / HTTP/1.0\r\n:a\r\n\r\n", 0, -1, "empty header name");
     PARSE("GET / HTTP/1.0\r\n :a\r\n\r\n", 0, -1, "header name (space only)");
 


### PR DESCRIPTION
Regarding https://tools.ietf.org/html/rfc7230#section-3.1.1, empty method and path are not allowed in HTTP/1.1. This PR does that check and return -1 if they are empty.