### PR TITLE
accept missing trailing space in status-line if reason-phrase is ommited

### DIFF
--- a/picohttpparser.c
+++ b/picohttpparser.c
@@ -429,13 +429,18 @@ static const char *parse_response(const char *buf, const char *buf_end, int *min
     }
     PARSE_INT_3(status);
 
-    /* skip space */
-    if (*buf++ != ' ') {
-        *ret = -1;
-        return NULL;
+    int has_sp = *buf == ' ';
+    if (has_sp) {
+        /* skip space */
+        ++buf;
     }
     /* get message */
     if ((buf = get_token_to_eol(buf, buf_end, msg, msg_len, ret)) == NULL) {
+        return NULL;
+    }
+    if (!has_sp && *msg_len != 0) {
+        /* garbage found after status code */
+        *ret = -1;
         return NULL;
     }
 

--- a/picohttpparser.c
+++ b/picohttpparser.c
@@ -429,16 +429,17 @@ static const char *parse_response(const char *buf, const char *buf_end, int *min
     }
     PARSE_INT_3(status);
 
-    int has_sp = *buf == ' ';
-    if (has_sp) {
-        /* skip space */
-        ++buf;
-    }
-    /* get message */
+    /* get message includig preceding space */
     if ((buf = get_token_to_eol(buf, buf_end, msg, msg_len, ret)) == NULL) {
         return NULL;
     }
-    if (!has_sp && *msg_len != 0) {
+    if (*msg_len == 0) {
+        /* ok */
+    } else if (**msg == ' ') {
+        /* remove preceding space */
+        ++*msg;
+        --*msg_len;
+    } else {
         /* garbage found after status code */
         *ret = -1;
         return NULL;

--- a/test.c
+++ b/test.c
@@ -236,6 +236,12 @@ static void test_response(void)
     PARSE("HTTP/1.2z 200 OK\r\n\r\n", 0, -1, "invalid http version 2");
     PARSE("HTTP/1.1  OK\r\n\r\n", 0, -1, "no status code");
 
+    PARSE("HTTP/1.1 200\r\n\r\n", 0, 0, "accept missing trailing whitespace in status-line");
+    ok(bufis(msg, msg_len, ""));
+    PARSE("HTTP/1.1 200X\r\n\r\n", 0, -1, "garbage after status 1");
+    PARSE("HTTP/1.1 200X \r\n\r\n", 0, -1, "garbage after status 2");
+    PARSE("HTTP/1.1 200X OK\r\n\r\n", 0, -1, "garbage after status 3");
+
     PARSE("HTTP/1.1 200 OK\r\nbar: \t b\t \t\r\n\r\n", 0, 0, "exclude leading and trailing spaces in header value");
     ok(bufis(headers[0].value, headers[0].value_len, "b"));
 


### PR DESCRIPTION
[RFC7230#3.1.2](https://tools.ietf.org/html/rfc7230#section-3.1.2) states that a SP is required even if reason-phrase is omitted, but we know that there are several servers that send responses with no space and no reason-phrase. This PR makes the behavior of picohttpparser more lenient to such responses.