### PR TITLE
accept multiple whitespaces between tokens

### DIFF
--- a/picohttpparser.c
+++ b/picohttpparser.c
@@ -359,9 +359,13 @@ static const char *parse_request(const char *buf, const char *buf_end, const cha
 
     /* parse request line */
     ADVANCE_TOKEN(*method, *method_len);
-    while (*buf == ' ') ++buf;
+    do {
+        ++buf;
+    } while (*buf == ' ');
     ADVANCE_TOKEN(*path, *path_len);
-    while (*buf == ' ') ++buf;
+    do {
+        ++buf;
+    } while (*buf == ' ');
     if (*method_len == 0 || *path_len == 0) {
         *ret = -1;
         return NULL;
@@ -418,11 +422,13 @@ static const char *parse_response(const char *buf, const char *buf_end, int *min
         return NULL;
     }
     /* skip space */
-    if (*buf++ != ' ') {
+    if (*buf != ' ') {
         *ret = -1;
         return NULL;
     }
-    while (*buf == ' ') ++buf;
+    do {
+        ++buf;
+    } while (*buf == ' ');
     /* parse status code, we want at least [:digit:][:digit:][:digit:]<other char> to try to parse */
     if (buf_end - buf < 4) {
         *ret = -2;
@@ -438,10 +444,10 @@ static const char *parse_response(const char *buf, const char *buf_end, int *min
         /* ok */
     } else if (**msg == ' ') {
         /* remove preceding space */
-        while (**msg == ' ') {
+        do {
             ++*msg;
             --*msg_len;
-        }
+        } while (**msg == ' ');
     } else {
         /* garbage found after status code */
         *ret = -1;

--- a/picohttpparser.c
+++ b/picohttpparser.c
@@ -359,9 +359,9 @@ static const char *parse_request(const char *buf, const char *buf_end, const cha
 
     /* parse request line */
     ADVANCE_TOKEN(*method, *method_len);
-    ++buf;
+    while (*buf == ' ') ++buf;
     ADVANCE_TOKEN(*path, *path_len);
-    ++buf;
+    while (*buf == ' ') ++buf;
     if (*method_len == 0 || *path_len == 0) {
         *ret = -1;
         return NULL;
@@ -422,6 +422,7 @@ static const char *parse_response(const char *buf, const char *buf_end, int *min
         *ret = -1;
         return NULL;
     }
+    while (*buf == ' ') ++buf;
     /* parse status code, we want at least [:digit:][:digit:][:digit:]<other char> to try to parse */
     if (buf_end - buf < 4) {
         *ret = -2;
@@ -437,8 +438,10 @@ static const char *parse_response(const char *buf, const char *buf_end, int *min
         /* ok */
     } else if (**msg == ' ') {
         /* remove preceding space */
-        ++*msg;
-        --*msg_len;
+        while (**msg == ' ') {
+            ++*msg;
+            --*msg_len;
+        }
     } else {
         /* garbage found after status code */
         *ret = -1;

--- a/test.c
+++ b/test.c
@@ -146,6 +146,8 @@ static void test_request(void)
     PARSE("GET / HTTP/1.0\r\nfoo: a \t \r\n\r\n", 0, 0, "exclude leading and trailing spaces in header value");
     ok(bufis(headers[0].value, headers[0].value_len, "a"));
 
+    PARSE("GET   /   HTTP/1.0\r\n\r\n", 0, 0, "accept multiple spaces between tokens");
+
 #undef PARSE
 }
 
@@ -244,6 +246,8 @@ static void test_response(void)
 
     PARSE("HTTP/1.1 200 OK\r\nbar: \t b\t \t\r\n\r\n", 0, 0, "exclude leading and trailing spaces in header value");
     ok(bufis(headers[0].value, headers[0].value_len, "b"));
+
+    PARSE("HTTP/1.1   200   OK\r\n\r\n", 0, 0, "accept multiple spaces between tokens");
 
 #undef PARSE
 }


### PR DESCRIPTION
Yes [RFC7230#3.1](https://tools.ietf.org/html/rfc7230#section-3.1) doesn't allow multiple whitespaces between tokens in start-line: that is,
```
request-line   = method SP request-target SP HTTP-version CRLF
```
```
status-line = HTTP-version SP status-code SP reason-phrase CRLF
```

but we occasionally see such requests sent by some kind of legacy devices. This PR makes the parser accept such requests and responses.