### PR TITLE
restrict the characters that can be used in method

### DIFF
--- a/picohttpparser.c
+++ b/picohttpparser.c
@@ -242,7 +242,8 @@ static const char *is_complete(const char *buf, const char *buf_end, size_t last
     } while (0)
 
 /* returned pointer is always within [buf, buf_end), or null */
-static const char *parse_http_method(const char *buf, const char *buf_end, const char **method, size_t *method_len, int *ret)
+static const char *parse_token(const char *buf, const char *buf_end, const char **token, size_t *token_len,
+                               char next_char, int *ret)
 {
     static const char ALIGNED(16) ranges[] = "\x00 "     /* control chars and up to SP */
                                              "\"\""      /* 0x22 */
@@ -261,7 +262,7 @@ static const char *parse_http_method(const char *buf, const char *buf_end, const
         CHECK_EOF();
     }
     while (1) {
-        if (*buf == ' ') {
+        if (*buf == next_char) {
             break;
         } else if (!token_char_map[(unsigned char)*buf]) {
             *ret = -1;
@@ -270,8 +271,8 @@ static const char *parse_http_method(const char *buf, const char *buf_end, const
         ++buf;
         CHECK_EOF();
     }
-    *method = buf_start;
-    *method_len = buf - buf_start;
+    *token = buf_start;
+    *token_len = buf - buf_start;
     return buf;
 }
 
@@ -314,34 +315,17 @@ static const char *parse_headers(const char *buf, const char *buf_end, struct ph
         if (!(*num_headers != 0 && (*buf == ' ' || *buf == '\t'))) {
             /* parsing name, but do not discard SP before colon, see
              * http://www.mozilla.org/security/announce/2006/mfsa2006-33.html */
-            headers[*num_headers].name = buf;
-            static const char ALIGNED(16) ranges1[] = "\x00 "  /* control chars and up to SP */
-                                                      "\"\""   /* 0x22 */
-                                                      "()"     /* 0x28,0x29 */
-                                                      ",,"     /* 0x2c */
-                                                      "//"     /* 0x2f */
-                                                      ":@"     /* 0x3a-0x40 */
-                                                      "[]"     /* 0x5b-0x5d */
-                                                      "{\377"; /* 0x7b-0xff */
-            int found;
-            buf = findchar_fast(buf, buf_end, ranges1, sizeof(ranges1) - 1, &found);
-            if (!found) {
-                CHECK_EOF();
+            const char *name;
+            size_t name_len = 0;
+            if ((buf = parse_token(buf, buf_end, &name, &name_len, ':', ret)) == NULL) {
+                return NULL;
             }
-            while (1) {
-                if (*buf == ':') {
-                    break;
-                } else if (!token_char_map[(unsigned char)*buf]) {
-                    *ret = -1;
-                    return NULL;
-                }
-                ++buf;
-                CHECK_EOF();
-            }
-            if ((headers[*num_headers].name_len = buf - headers[*num_headers].name) == 0) {
+            if (name_len == 0) {
                 *ret = -1;
                 return NULL;
             }
+            headers[*num_headers].name = name;
+            headers[*num_headers].name_len = name_len;
             ++buf;
             for (;; ++buf) {
                 CHECK_EOF();
@@ -386,7 +370,7 @@ static const char *parse_request(const char *buf, const char *buf_end, const cha
     }
 
     /* parse request line */
-    if ((buf = parse_http_method(buf, buf_end, method, method_len, ret)) == NULL) {
+    if ((buf = parse_token(buf, buf_end, method, method_len, ' ', ret)) == NULL) {
         return NULL;
     }
     do {

--- a/test.c
+++ b/test.c
@@ -122,6 +122,7 @@ static void test_request(void)
 
     PARSE("G\0T / HTTP/1.0\r\n\r\n", 0, -1, "NUL in method");
     PARSE("G\tT / HTTP/1.0\r\n\r\n", 0, -1, "tab in method");
+    PARSE(":GET / HTTP/1.0\r\n\r\n", 0, -1, "invalid method");
     PARSE("GET /\x7fhello HTTP/1.0\r\n\r\n", 0, -1, "DEL in uri-path");
     PARSE("GET / HTTP/1.0\r\na\0b: c\r\n\r\n", 0, -1, "NUL in header name");
     PARSE("GET / HTTP/1.0\r\nab: c\0d\r\n\r\n", 0, -1, "NUL in header value");


### PR DESCRIPTION
Fail if the method doesn't follow the spec.