### PR TITLE
Tighten the parsing logic of chunked encoding

### DIFF
--- a/picohttpparser.c
+++ b/picohttpparser.c
@@ -557,6 +557,18 @@ ssize_t phr_decode_chunked(struct phr_chunked_decoder *decoder, char *buf, size_
                         ret = -1;
                         goto Exit;
                     }
+                    /* the only characters that may appear after the chunk size are BWS, semicolon, or CRLF */
+                    switch (buf[src]) {
+                    case ' ':
+                    case '\011':
+                    case ';':
+                    case '\012':
+                    case '\015':
+                        break;
+                    default:
+                        ret = -1;
+                        goto Exit;
+                    }
                     break;
                 }
                 if (decoder->_hex_count == sizeof(size_t) * 2) {

--- a/test.c
+++ b/test.c
@@ -410,6 +410,7 @@ static void test_chunked(void)
         chunked_test_runners[i](__LINE__, 0, "b\r\nhello world\r\n0\r\n", "hello world", 0);
         chunked_test_runners[i](__LINE__, 0, "6\r\nhello \r\n5\r\nworld\r\n0\r\n", "hello world", 0);
         chunked_test_runners[i](__LINE__, 0, "6;comment=hi\r\nhello \r\n5\r\nworld\r\n0\r\n", "hello world", 0);
+        chunked_test_runners[i](__LINE__, 0, "6 ; comment\r\nhello \r\n5\r\nworld\r\n0\r\n", "hello world", 0);
         chunked_test_runners[i](__LINE__, 0, "6\r\nhello \r\n5\r\nworld\r\n0\r\na: b\r\nc: d\r\n\r\n", "hello world",
                                 sizeof("a: b\r\nc: d\r\n\r\n") - 1);
         chunked_test_runners[i](__LINE__, 0, "b\r\nhello world\r\n0\r\n", "hello world", 0);
@@ -421,6 +422,7 @@ static void test_chunked(void)
         test_chunked_failure(__LINE__, "6\r\nhello \r\nffffffffffffffff\r\nabcdefg", -2);
         test_chunked_failure(__LINE__, "6\r\nhello \r\nfffffffffffffffff\r\nabcdefg", -1);
     }
+    test_chunked_failure(__LINE__, "1x\r\na\r\n0\r\n", -1);
 }
 
 static void test_chunked_consume_trailer(void)


### PR DESCRIPTION
According to RFC 9112, a chunk size consists of a series of hexadecimal characters, which may be optionally followed by whitespace and extensions beginning with a semicolon.

Picohttpparser's parsing logic has been more permissive. It recognizes a sequence of hexadecimal characters as the size, disregarding any subsequent characters. For example, although "123x\r\n" does not conform to RFC 9112, picohttpparser has interpreted this line as indicating a chunk size of 291 (0x123) bytes.

Recently, concerns have surfaced about this lenient behavior. Specifically, there is a risk that if a client, acting as a proxy, forwards a malformed chunk size which is interpreted differently by that client, it could enable splitting attacks.

To mitigate the concern, this PR tightens the parsing logic. Now, the first non-hexadecimal character must be a whitespace, a semicolon, or the end of line. While it is the responsibility of each endpoint to send HTTP messages in accordance with the specifications, these changes ensure a more robust handling of potential deviations.

We express our gratitude to Ben Kallus and Keran Mu for independently bringing this issue to our attention.