### PR TITLE
Detect and reject excess overhead in chunked encoding

### DIFF
--- a/picohttpparser.h
+++ b/picohttpparser.h
@@ -27,6 +27,7 @@
 #ifndef picohttpparser_h
 #define picohttpparser_h
 
+#include <stdint.h>
 #include <sys/types.h>
 
 #ifdef _MSC_VER
@@ -64,6 +65,8 @@ struct phr_chunked_decoder {
     char consume_trailer;       /* if trailing headers should be consumed */
     char _hex_count;
     char _state;
+    uint64_t _total_read;
+    uint64_t _total_overhead;
 };
 
 /* the function rewrites the buffer given as (buf, bufsz) removing the chunked-


### PR DESCRIPTION
As discussed in https://nowotarski.info/http-chunk-extensions/, HTTP chunked encoding can have large amount of overhead. When mounting a denial-of-service attack, an attacker might use HTTP requests that contain such chunks.

picohttpparser is immune to such attacks; it does not consume excess memory due to this type of attack. The processing speed of such chunks is much faster (e.g., ~500MB on modern CPU core) than the processing of HTTP requests in general.

Considering these aspects, we do not consider this as a vulnerability.

Nonetheless, it is always good to detect and reject these kind of attacks; hence the PR.

With this PR, picohttpparser rejects HTTP payload using chunked encoding with the following properties:
* total size is larger than 100KB, and
* cumulative size of chunk headers consists more than 80% of the total size.

The issue was reported by Bartek Nowotarski.