### PR TITLE
chore: Fix make test warning

### DIFF
--- a/test.c
+++ b/test.c
@@ -477,7 +477,7 @@ static ssize_t do_test_chunked_overhead(size_t chunk_len, size_t chunk_count, co
 
     for (size_t i = 0; i < chunk_count; ++i) {
         /* build and feed the chunk header */
-        bufsz = (size_t)sprintf(buf, "%zx%s\r\n", chunk_len, extra);
+        bufsz = (size_t)snprintf(buf, sizeof(buf), "%zx%s\r\n", chunk_len, extra);
         if ((ret = phr_decode_chunked(&dec, buf, &bufsz)) != -2)
             goto Exit;
         assert(bufsz == 0);


### PR DESCRIPTION
* sprintf -> snprintf in test.c

I found build warnings on MacOS. so I fixed with `snprintf` following warning message.
```
% make test
cc -Wall -fsanitize=address,undefined  -o test-bin picohttpparser.c picotest/picotest.c test.c
test.c:480:25: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
        bufsz = (size_t)sprintf(buf, "%zx%s\r\n", chunk_len, extra);
                        ^
/Library/Developer/CommandLineTools/SDKs/MacOSX15.0.sdk/usr/include/_stdio.h:274:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Library/Developer/CommandLineTools/SDKs/MacOSX15.0.sdk/usr/include/sys/cdefs.h:218:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
1 warning generated.
```